### PR TITLE
Reusable connections

### DIFF
--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -44,7 +44,7 @@ class AdapterFactory
      */
     protected static $instance;
 
-	protected static $adapterInstances = [];
+	protected $adapterInstances = [];
 
     /**
      * Get the factory singleton instance.

--- a/src/Phinx/Db/Adapter/AdapterFactory.php
+++ b/src/Phinx/Db/Adapter/AdapterFactory.php
@@ -44,6 +44,8 @@ class AdapterFactory
      */
     protected static $instance;
 
+	protected static $adapterInstances = [];
+
     /**
      * Get the factory singleton instance.
      *
@@ -67,7 +69,7 @@ class AdapterFactory
         'pgsql'  => 'Phinx\Db\Adapter\PostgresAdapter',
         'sqlite' => 'Phinx\Db\Adapter\SQLiteAdapter',
         'sqlsrv' => 'Phinx\Db\Adapter\SqlServerAdapter',
-	'bamboohrmysql' => 'Phinx\Db\Adapter\BambooHRMysqlAdapter',
+		'bamboohrmysql' => 'Phinx\Db\Adapter\BambooHRMysqlAdapter',
     );
 
     /**
@@ -125,11 +127,16 @@ class AdapterFactory
      * @param  array  $options
      * @return AdapterInterface
      */
-    public function getAdapter($name, array $options)
-    {
-        $class = $this->getClass($name);
-        return new $class($options);
-    }
+	public function getAdapter($name, array $options)
+	{
+		if (!isset($this->adapterInstances[$name]) || empty($this->adapterInstances[$name])) {
+			$class = $this->getClass($name);
+			$this->adapterInstances[$name] = new $class($options);
+		}
+		$adapter = $this->adapterInstances[$name];
+		$adapter->setOptions($options);
+		return $adapter;
+	}
 
     /**
      * Add or replace a wrapper with a fully qualified class name.

--- a/src/Phinx/Db/Adapter/BambooHRMysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/BambooHRMysqlAdapter.php
@@ -4,6 +4,36 @@ namespace Phinx\Db\Adapter;
 
 class BambooHRMysqlAdapter extends \Phinx\Db\Adapter\MysqlAdapter {
 
+	private $dbName = null;
+
+	/**
+	 * Gets the database connection
+	 *
+	 * @return \PDO
+	 */
+	public function getConnection() {
+		$options = $this->getOptions();
+		if (null === $this->connection || $this->dbName !== $options['name']) {
+			$this->connect();
+		}
+		return $this->connection;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function connect() {
+		if (!empty($this->db)) {
+			$options = $this->getOptions();
+			$this->dbName = $options['name'];
+			$this->connection->exec('USE ' . $this->dbName);
+			$this->setConnection($this->db);
+		} else {
+			parent::connect();
+		}
+
+	}
+
 	/**
 	 * 
 	 * @param type $tableName table name

--- a/src/Phinx/Db/Adapter/BambooHRMysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/BambooHRMysqlAdapter.php
@@ -26,7 +26,7 @@ class BambooHRMysqlAdapter extends \Phinx\Db\Adapter\MysqlAdapter {
 		if (!empty($this->db)) {
 			$options = $this->getOptions();
 			$this->dbName = $options['name'];
-			$this->connection->exec('USE ' . $this->dbName);
+			$this->db->exec('USE ' . $this->dbName);
 			$this->setConnection($this->db);
 		} else {
 			parent::connect();

--- a/src/Phinx/Db/Adapter/MysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/MysqlAdapter.php
@@ -62,6 +62,8 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     const INT_REGULAR = 4294967295;
     const INT_BIG     = 18446744073709551615;
 
+	protected $db = null;
+
     /**
      * {@inheritdoc}
      */
@@ -90,7 +92,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
                 }
             }
 
-            $dsn .= ';dbname=' . $options['name'];
+           // $dsn .= ';dbname=' . $options['name'];
 
             // charset support
             if (!empty($options['charset'])) {
@@ -109,13 +111,14 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
 
             try {
                 $db = new \PDO($dsn, $options['user'], $options['pass'], $driverOptions);
+	            $db->exec('USE ' . $options['name']);
             } catch (\PDOException $exception) {
                 throw new \InvalidArgumentException(sprintf(
                     'There was a problem connecting to the database: %s',
                     $exception->getMessage()
                 ));
             }
-
+			$this->db = $db;
             $this->setConnection($db);
         }
     }

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -108,10 +108,11 @@ class Manager
 			. ' <error>** MISSING **</error>'
 		    );
 		}
-	    } finally {
+	    } catch (\Exception $exception) {
 	        if ($env->getAdapter() !== null) {
 		        $env->getAdapter()->disconnect();
 	        }
+		    throw $exception;
 	    }
         } else {
             // there are no migrations
@@ -251,10 +252,11 @@ class Manager
 			$this->executeMigration($environment, $migration, MigrationInterface::UP);
 		    }
 		}
-	} finally {
+	} catch (\Exception $exception) {
 	    if ($env->getAdapter() !== null) {
 		    $env->getAdapter()->disconnect();
 	    }
+		throw $exception;
 	}
     }
 
@@ -343,10 +345,11 @@ class Manager
 			$this->executeMigration($environment, $migration, MigrationInterface::DOWN);
 		    }
 		}
-	} finally {
+	} catch (\Exception $exception) {
 	    if ($env->getAdapter() !== null) {
 		    $env->getAdapter()->disconnect();
 	    }
+		throw $exception;
 	}
     }
 


### PR DESCRIPTION
- updated the AdapterFactory so it will mange adapter instances. `getAdapter` was updated to reuse the adapter instead of instantiating a new one every time. This allows for the member variables to persist and track `$dbname` and `$db`.
- The BambooHRMysqlAdapter was updated to manage connections. The `getConnection` overrides the parent so it change check if the name of the database has changed. If it has, it will call connect. `connect` was updated to check for the existence of a database. If the database is not empty, it will witch to the new database calling `exec('USE {db_name}')` and then update the connection.
- The MysqlAdapter was updated with the `$db` member variable. The `connect` method was updated to remove the setting of the dynamo in the DSN (to make sure no database is ever specified in the PDO. We then call `exec('USE {db_name}')` right after the connection to the database is established.
- The manager was updated to fix the try finally and change them to try catch so the adapter connection can persist between requests.
