### PR TITLE
dropForeignKey method fix

### DIFF
--- a/src/Phinx/Db/Adapter/BambooHRMysqlAdapter.php
+++ b/src/Phinx/Db/Adapter/BambooHRMysqlAdapter.php
@@ -63,7 +63,7 @@ class BambooHRMysqlAdapter extends \Phinx\Db\Adapter\MysqlAdapter {
 		if ($constraint) {
 			$this->execute(
 				sprintf(
-					'ALTER TABLE `%s` DROP FOREIGN KEY %s', $this->quoteTableName($tableName), $constraint
+					'ALTER TABLE %s DROP FOREIGN KEY %s', $this->quoteTableName($tableName), $constraint
 				)
 			);
 			$this->endCommandTimer();


### PR DESCRIPTION
Remove ticks around table name when getting quoted table name.
