### PR TITLE
Without an adapter, in the case of an error, quit.

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -254,6 +254,9 @@ class Manager
 	} finally {
 	    if ($env->getAdapter() !== null) {
 		    $env->getAdapter()->disconnect();
+	    } else {
+	    	echo "couldn't disconnect. Exiting to avoid eating up connections.";
+	    	exit();
 	    }
 	}
     }


### PR DESCRIPTION
We still sometimes run out of connections when running migrations. This should warn us when that might happen, because we can't disconnect.
